### PR TITLE
fix: notarize macOS binary by submitting archive

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,7 @@ release:
 notarize:
   macos:
     - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
+      artifacts: archive
       sign:
         certificate: "{{.Env.MACOS_SIGN_P12}}"
         password: "{{.Env.MACOS_SIGN_PASSWORD}}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,7 +35,6 @@ release:
 notarize:
   macos:
     - enabled: '{{ isEnvSet "MACOS_SIGN_P12" }}'
-      artifacts: archive
       sign:
         certificate: "{{.Env.MACOS_SIGN_P12}}"
         password: "{{.Env.MACOS_SIGN_PASSWORD}}"
@@ -43,6 +42,8 @@ notarize:
         issuer_id: "{{.Env.MACOS_NOTARY_ISSUER_ID}}"
         key_id: "{{.Env.MACOS_NOTARY_KEY_ID}}"
         key: "{{.Env.MACOS_NOTARY_KEY}}"
+        timeout: 20m
+        wait: true
 
 dockers_v2:
   - images:


### PR DESCRIPTION
This pull request makes a small configuration change to the `.goreleaser.yml` file to improve the notarization process for macOS builds.

* Set the notarization `timeout` to 20 minutes and enabled `wait` to ensure the process completes before continuing.