### PR TITLE
Fix host directory policy boundary checks

### DIFF
--- a/pkg/resource/v1/host_dir_policy.go
+++ b/pkg/resource/v1/host_dir_policy.go
@@ -58,10 +58,10 @@ func (policy HostDirPolicy) Validate(path string, readOnly bool) bool {
 		return false
 	}
 
-	return strings.HasPrefix(
-		strings.TrimSuffix(path, "/"),
-		strings.TrimSuffix(policy.PathPrefix, "/"),
-	)
+	path = strings.TrimSuffix(path, "/")
+	pathPrefix := strings.TrimSuffix(policy.PathPrefix, "/")
+
+	return path == pathPrefix || strings.HasPrefix(path, pathPrefix+"/")
 }
 
 func (policy HostDirPolicy) String() string {

--- a/pkg/resource/v1/host_dir_policy_test.go
+++ b/pkg/resource/v1/host_dir_policy_test.go
@@ -45,6 +45,11 @@ func TestHostDirPolicyValidate(t *testing.T) {
 }
 
 func TestHostDirPolicyValidatePathBoundary(t *testing.T) {
+	const (
+		localPathPrefix = "/src/"
+		githubURLPrefix = "https://github.com"
+	)
+
 	testCases := []struct {
 		name       string
 		pathPrefix string
@@ -53,13 +58,13 @@ func TestHostDirPolicyValidatePathBoundary(t *testing.T) {
 	}{
 		{
 			name:       "local policy allows its exact path",
-			pathPrefix: "/src/",
+			pathPrefix: localPathPrefix,
 			path:       "/src",
 			allowed:    true,
 		},
 		{
 			name:       "local policy allows descendants",
-			pathPrefix: "/src/",
+			pathPrefix: localPathPrefix,
 			path:       "/src/project",
 			allowed:    true,
 		},
@@ -67,11 +72,13 @@ func TestHostDirPolicyValidatePathBoundary(t *testing.T) {
 			name:       "local policy without trailing slash rejects sibling sharing its prefix",
 			pathPrefix: "/src",
 			path:       "/src-private",
+			allowed:    false,
 		},
 		{
 			name:       "local policy rejects sibling sharing its prefix",
-			pathPrefix: "/src/",
+			pathPrefix: localPathPrefix,
 			path:       "/src-private",
+			allowed:    false,
 		},
 		{
 			name:       "local root policy allows descendants",
@@ -83,33 +90,37 @@ func TestHostDirPolicyValidatePathBoundary(t *testing.T) {
 			name:       "local root policy rejects remote URLs",
 			pathPrefix: "/",
 			path:       "https://github.com/archive.tar.gz",
+			allowed:    false,
 		},
 		{
 			name:       "URL policy allows its exact host",
-			pathPrefix: "https://github.com/",
-			path:       "https://github.com",
+			pathPrefix: githubURLPrefix + "/",
+			path:       githubURLPrefix,
 			allowed:    true,
 		},
 		{
 			name:       "URL policy allows paths on its host",
-			pathPrefix: "https://github.com",
+			pathPrefix: githubURLPrefix,
 			path:       "https://github.com/actions/archive.tar.gz",
 			allowed:    true,
 		},
 		{
 			name:       "URL policy rejects lookalike host",
-			pathPrefix: "https://github.com",
+			pathPrefix: githubURLPrefix,
 			path:       "https://github.com.attacker.com/archive.tar.gz",
+			allowed:    false,
 		},
 		{
 			name:       "URL policy with trailing slash rejects lookalike host",
-			pathPrefix: "https://github.com/",
+			pathPrefix: githubURLPrefix + "/",
 			path:       "https://github.com.attacker.com/archive.tar.gz",
+			allowed:    false,
 		},
 		{
 			name:       "URL policy rejects host concealed by userinfo",
-			pathPrefix: "https://github.com",
+			pathPrefix: githubURLPrefix,
 			path:       "https://github.com@attacker.example/archive.tar.gz",
+			allowed:    false,
 		},
 		{
 			name:       "URL path policy allows descendants",
@@ -121,12 +132,13 @@ func TestHostDirPolicyValidatePathBoundary(t *testing.T) {
 			name:       "URL path policy rejects sibling sharing its prefix",
 			pathPrefix: "https://github.com/actions",
 			path:       "https://github.com/actions-private/archive.tar.gz",
+			allowed:    false,
 		},
 	}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.name, func(t *testing.T) {
-			policy := v1.HostDirPolicy{PathPrefix: testCase.pathPrefix}
+			policy := v1.HostDirPolicy{PathPrefix: testCase.pathPrefix, ReadOnly: false}
 
 			require.Equal(t, testCase.allowed, policy.Validate(testCase.path, false))
 		})

--- a/pkg/resource/v1/host_dir_policy_test.go
+++ b/pkg/resource/v1/host_dir_policy_test.go
@@ -44,6 +44,95 @@ func TestHostDirPolicyValidate(t *testing.T) {
 	require.False(t, policy.Validate("/..", true))
 }
 
+func TestHostDirPolicyValidatePathBoundary(t *testing.T) {
+	testCases := []struct {
+		name       string
+		pathPrefix string
+		path       string
+		allowed    bool
+	}{
+		{
+			name:       "local policy allows its exact path",
+			pathPrefix: "/src/",
+			path:       "/src",
+			allowed:    true,
+		},
+		{
+			name:       "local policy allows descendants",
+			pathPrefix: "/src/",
+			path:       "/src/project",
+			allowed:    true,
+		},
+		{
+			name:       "local policy without trailing slash rejects sibling sharing its prefix",
+			pathPrefix: "/src",
+			path:       "/src-private",
+		},
+		{
+			name:       "local policy rejects sibling sharing its prefix",
+			pathPrefix: "/src/",
+			path:       "/src-private",
+		},
+		{
+			name:       "local root policy allows descendants",
+			pathPrefix: "/",
+			path:       "/src/project",
+			allowed:    true,
+		},
+		{
+			name:       "local root policy rejects remote URLs",
+			pathPrefix: "/",
+			path:       "https://github.com/archive.tar.gz",
+		},
+		{
+			name:       "URL policy allows its exact host",
+			pathPrefix: "https://github.com/",
+			path:       "https://github.com",
+			allowed:    true,
+		},
+		{
+			name:       "URL policy allows paths on its host",
+			pathPrefix: "https://github.com",
+			path:       "https://github.com/actions/archive.tar.gz",
+			allowed:    true,
+		},
+		{
+			name:       "URL policy rejects lookalike host",
+			pathPrefix: "https://github.com",
+			path:       "https://github.com.attacker.com/archive.tar.gz",
+		},
+		{
+			name:       "URL policy with trailing slash rejects lookalike host",
+			pathPrefix: "https://github.com/",
+			path:       "https://github.com.attacker.com/archive.tar.gz",
+		},
+		{
+			name:       "URL policy rejects host concealed by userinfo",
+			pathPrefix: "https://github.com",
+			path:       "https://github.com@attacker.example/archive.tar.gz",
+		},
+		{
+			name:       "URL path policy allows descendants",
+			pathPrefix: "https://github.com/actions",
+			path:       "https://github.com/actions/runner/archive.tar.gz",
+			allowed:    true,
+		},
+		{
+			name:       "URL path policy rejects sibling sharing its prefix",
+			pathPrefix: "https://github.com/actions",
+			path:       "https://github.com/actions-private/archive.tar.gz",
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			policy := v1.HostDirPolicy{PathPrefix: testCase.pathPrefix}
+
+			require.Equal(t, testCase.allowed, policy.Validate(testCase.path, false))
+		})
+	}
+}
+
 func TestHostDirPolicyValidateReadOnly(t *testing.T) {
 	policy := &v1.HostDirPolicy{PathPrefix: "/Users/ci/src", ReadOnly: true}
 


### PR DESCRIPTION
## Summary

Host directory policies previously used raw string-prefix matching after trimming trailing slashes. This allowed sibling directories and unrelated URL hosts that shared an allowed prefix.

- Require an exact match or a `/`-delimited descendant.
- Reject sibling directories, lookalike URL hosts, userinfo-based host disguises, and sibling URL paths.
- Preserve valid exact matches, descendants, trailing-slash handling, root policies, and read-only behavior.

## Testing

- `go test ./pkg/resource/v1 ./internal/controller/... -count=1`