### PR TITLE
Add --no-audio support to VM spec

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -743,6 +743,10 @@ components:
           type: boolean
           description: Enable nested virtualization
           default: false
+        noAudio:
+          type: boolean
+          description: Whether to disable audio pass-through to the host
+          default: false
         username:
           type: string
           description: SSH username to use when connecting to a VM

--- a/internal/command/create/vm.go
+++ b/internal/command/create/vm.go
@@ -28,6 +28,7 @@ var netSoftnetBlock []string
 var netBridged string
 var headless bool
 var nested bool
+var noAudio bool
 var suspendable bool
 var username string
 var password string
@@ -70,6 +71,7 @@ func newCreateVMCommand() *cobra.Command {
 	command.Flags().StringVar(&netBridged, "net-bridged", "", "whether to use Bridged network mode")
 	command.Flags().BoolVar(&headless, "headless", true, "whether to run without graphics")
 	command.Flags().BoolVar(&nested, "nested", false, "enable nested virtualization")
+	command.Flags().BoolVar(&noAudio, "no-audio", false, "disable audio pass-through to the host")
 	command.Flags().BoolVar(&suspendable, "suspendable", false, "treat the VM as suspendable, "+
 		"disabling certain devices for suspendability support and issuing \"tart suspend\" instead of \"tart stop\" "+
 		"when VM's specification is updated, thus preserving the VM's state between specification generations")
@@ -156,6 +158,7 @@ func runCreateVM(cmd *cobra.Command, args []string) error {
 		NetBridged:   netBridged,
 		Headless:     headless,
 		Nested:       nested,
+		NoAudio:      noAudio,
 		Username:     username,
 		Password:     password,
 		RandomSerial: randomSerial,

--- a/internal/command/get/vm.go
+++ b/internal/command/get/vm.go
@@ -98,6 +98,7 @@ func runGetVM(cmd *cobra.Command, args []string) error {
 	table.AddRow("Bridged networking interface", nonEmptyOrNone(vm.NetBridged))
 	table.AddRow("Headless mode", vm.Headless)
 	table.AddRow("Nested virtualization", vm.Nested)
+	table.AddRow("Audio disabled", vm.NoAudio)
 	table.AddRow("Status", vm.Status)
 	table.AddRow("Status message", vm.StatusMessage)
 	table.AddRow("Assigned worker", nonEmptyOrNone(vm.Worker))

--- a/internal/worker/vmmanager/tart/tart.go
+++ b/internal/worker/vmmanager/tart/tart.go
@@ -303,6 +303,10 @@ func (vm *VM) run(ctx context.Context, eventStreamer *client.EventStreamer) {
 		runArgs = append(runArgs, "--nested")
 	}
 
+	if vm.resource.NoAudio {
+		runArgs = append(runArgs, "--no-audio")
+	}
+
 	if vm.resource.Suspendable {
 		runArgs = append(runArgs, "--suspendable")
 	}

--- a/pkg/resource/v1/v1.go
+++ b/pkg/resource/v1/v1.go
@@ -32,6 +32,7 @@ type VM struct {
 	NetBridged      string          `json:"net-bridged,omitempty"`
 	Headless        bool            `json:"headless,omitempty"`
 	Nested          bool            `json:"nested,omitempty"`
+	NoAudio         bool            `json:"noAudio,omitempty"`
 
 	VMSpec
 	VMSpecReadOnly


### PR DESCRIPTION
## Summary

Add a `NoAudio` field to the VM spec, threaded through to `tart run --no-audio`.

## Why

`tart run` supports `--no-audio` to disable host audio pass-through, but there's no way to request it through a VM's spec today — `Headless`, `Nested`, and `Suspendable` each have a flag/field, but audio pass-through doesn't.

This matters on worker hosts with no audio hardware: pass-through makes the guest's CoreAudio depend on host audio services that don't exist, and jobs initializing real-time audio (e.g. `AURemoteIO`) can abort rather than falling back gracefully. `--no-audio` gives the guest a null speaker device with no host dependency instead.

## What changed

Mirrors the existing `Headless`/`Nested` pattern — same struct shape, CLI flag style, `orchard get vm` display row, and OpenAPI schema addition:

- `pkg/resource/v1/v1.go`: `NoAudio bool` field on `VM`
- `internal/worker/vmmanager/tart/tart.go`: appends `--no-audio` to the `tart run` args when set
- `internal/command/create/vm.go`: `--no-audio` flag on `orchard create vm`
- `internal/command/get/vm.go`: displays it in `orchard get vm`
- `api/openapi.yaml`: schema addition

Defaults to `false` (pass-through on, today's behavior) — backward compatible, no behavior change unless a VM opts in.

## Validation

- `go build ./...`
- `go vet ./...`
- `gofmt -l .`
- `go test ./pkg/resource/v1/...`