### PR TITLE
Apply backpressure to live exec output subscribers

### DIFF
--- a/internal/controller/exec_sessions.go
+++ b/internal/controller/exec_sessions.go
@@ -251,24 +251,7 @@ func (subscriber *execSessionSubscriber) enqueue(frame *execstream.Frame) bool {
 	subscriber.sendMu.Lock()
 	defer subscriber.sendMu.Unlock()
 
-	if subscriber.alreadySentLocked(frame) {
-		return true
-	}
-
-	select {
-	case <-subscriber.closed:
-		return false
-	default:
-	}
-
-	select {
-	case subscriber.frames <- subscriber.markSentLocked(frame):
-		return true
-	case <-subscriber.closed:
-		return false
-	default:
-		return false
-	}
+	return subscriber.sendLocked(frame)
 }
 
 func (subscriber *execSessionSubscriber) sendHistory(frames []*execstream.Frame) bool {

--- a/internal/controller/exec_sessions.go
+++ b/internal/controller/exec_sessions.go
@@ -15,14 +15,16 @@ import (
 const execSessionReplayBufferBytes = 4 * 1024 * 1024
 
 type execSessionPolicy struct {
-	closeOnDetach   bool
-	retainAfterExit bool
-	replayEnabled   bool
+	closeOnDetach                 bool
+	retainAfterExit               bool
+	replayEnabled                 bool
+	blockOnSubscriberBackpressure bool
 }
 
 var (
 	legacyExecSessionPolicy = execSessionPolicy{
-		closeOnDetach: true,
+		closeOnDetach:                 true,
+		blockOnSubscriberBackpressure: true,
 	}
 	reconnectableExecSessionPolicy = execSessionPolicy{
 		retainAfterExit: true,
@@ -247,11 +249,32 @@ func newExecSessionSubscriber() *execSessionSubscriber {
 	}
 }
 
-func (subscriber *execSessionSubscriber) enqueue(frame *execstream.Frame) bool {
+func (subscriber *execSessionSubscriber) enqueue(frame *execstream.Frame, block bool) bool {
 	subscriber.sendMu.Lock()
 	defer subscriber.sendMu.Unlock()
 
-	return subscriber.sendLocked(frame)
+	if block {
+		return subscriber.sendLocked(frame)
+	}
+
+	if subscriber.alreadySentLocked(frame) {
+		return true
+	}
+
+	select {
+	case <-subscriber.closed:
+		return false
+	default:
+	}
+
+	select {
+	case subscriber.frames <- subscriber.markSentLocked(frame):
+		return true
+	case <-subscriber.closed:
+		return false
+	default:
+		return false
+	}
 }
 
 func (subscriber *execSessionSubscriber) sendHistory(frames []*execstream.Frame) bool {
@@ -612,7 +635,7 @@ func (session *execSession) recordFrame(frame *execstream.Frame) {
 	session.mu.Unlock()
 
 	for _, subscriber := range subscribers {
-		if !subscriber.enqueue(frame) {
+		if !subscriber.enqueue(frame, session.policy.blockOnSubscriberBackpressure) {
 			session.dropSubscriber(subscriber)
 		}
 	}

--- a/internal/controller/exec_sessions_test.go
+++ b/internal/controller/exec_sessions_test.go
@@ -266,6 +266,56 @@ func TestExecSessionHistoryReplayStreamsPastSubscriberBuffer(t *testing.T) {
 	}, time.Second, 10*time.Millisecond)
 }
 
+func TestExecSessionLiveOutputAppliesBackpressure(t *testing.T) {
+	session := newManualExecSessionForTest(execSessionKey{vmName: "vm", sessionID: "session"}, nil)
+	session.policy = legacyExecSessionPolicy
+	t.Cleanup(session.close)
+
+	subscriber, err := session.attach()
+	require.NoError(t, err)
+
+	const frameCount = 256
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < frameCount; i++ {
+			session.recordFrame(&execstream.Frame{
+				Type: execstream.FrameTypeStdout,
+				Data: []byte{byte(i)},
+			})
+		}
+		session.recordFrame(&execstream.Frame{
+			Type: execstream.FrameTypeExit,
+			Exit: &execstream.Exit{Code: 0},
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		return len(subscriber.frames) == cap(subscriber.frames)
+	}, time.Second, time.Millisecond)
+
+	for i := 0; i < frameCount; i++ {
+		frame, ok := <-subscriber.frames
+		require.True(t, ok, "subscriber closed before output frame %d", i)
+		require.Equal(t, execstream.FrameTypeStdout, frame.Type)
+		require.Equal(t, []byte{byte(i)}, frame.Data)
+	}
+
+	exitFrame, ok := <-subscriber.frames
+	require.True(t, ok, "subscriber closed before the exit frame")
+	require.Equal(t, execstream.FrameTypeExit, exitFrame.Type)
+	require.EqualValues(t, 0, exitFrame.Exit.Code)
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
+
 func TestExecSessionDetachKeepsProcessAlive(t *testing.T) {
 	registry := newExecSessionRegistry()
 	session := newManualExecSessionForTest(execSessionKey{vmName: "vm", sessionID: "session"}, registry)

--- a/internal/controller/exec_sessions_test.go
+++ b/internal/controller/exec_sessions_test.go
@@ -280,13 +280,21 @@ func TestExecSessionLiveOutputAppliesBackpressure(t *testing.T) {
 		defer close(done)
 		for i := range frameCount {
 			session.recordFrame(&execstream.Frame{
-				Type: execstream.FrameTypeStdout,
-				Data: []byte{byte(i)},
+				Type:      execstream.FrameTypeStdout,
+				Data:      []byte{byte(i)},
+				Terminal:  nil,
+				Exit:      nil,
+				Error:     "",
+				Watermark: 0,
 			})
 		}
 		session.recordFrame(&execstream.Frame{
-			Type: execstream.FrameTypeExit,
-			Exit: &execstream.Exit{Code: 0},
+			Type:      execstream.FrameTypeExit,
+			Data:      nil,
+			Terminal:  nil,
+			Exit:      &execstream.Exit{Code: 0},
+			Error:     "",
+			Watermark: 0,
 		})
 	}()
 
@@ -314,6 +322,77 @@ func TestExecSessionLiveOutputAppliesBackpressure(t *testing.T) {
 			return false
 		}
 	}, time.Second, time.Millisecond)
+}
+
+func TestReconnectableExecSessionDropsStalledSubscriber(t *testing.T) {
+	session := newManualExecSessionForTest(execSessionKey{vmName: "vm", sessionID: "session"}, nil)
+	t.Cleanup(session.close)
+
+	stalledSubscriber, err := session.attach()
+	require.NoError(t, err)
+
+	for i := range cap(stalledSubscriber.frames) {
+		session.recordFrame(&execstream.Frame{
+			Type:      execstream.FrameTypeStdout,
+			Data:      []byte{byte(i)},
+			Terminal:  nil,
+			Exit:      nil,
+			Error:     "",
+			Watermark: 0,
+		})
+	}
+
+	healthySubscriber, err := session.attach()
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		session.recordFrame(&execstream.Frame{
+			Type:      execstream.FrameTypeStdout,
+			Data:      []byte("still running"),
+			Terminal:  nil,
+			Exit:      nil,
+			Error:     "",
+			Watermark: 0,
+		})
+		session.recordFrame(&execstream.Frame{
+			Type:      execstream.FrameTypeExit,
+			Data:      nil,
+			Terminal:  nil,
+			Exit:      &execstream.Exit{Code: 0},
+			Error:     "",
+			Watermark: 0,
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("a stalled reconnectable subscriber blocked live output")
+	}
+
+	outputFrame := <-healthySubscriber.frames
+	require.Equal(t, execstream.FrameTypeStdout, outputFrame.Type)
+	require.Equal(t, []byte("still running"), outputFrame.Data)
+
+	exitFrame := <-healthySubscriber.frames
+	require.Equal(t, execstream.FrameTypeExit, exitFrame.Type)
+	require.EqualValues(t, 0, exitFrame.Exit.Code)
+
+	select {
+	case <-stalledSubscriber.closed:
+	default:
+		t.Fatal("the stalled reconnectable subscriber was not dropped")
+	}
+
+	reconnectedSubscriber, err := session.attach()
+	require.NoError(t, err)
+	session.sendHistory(reconnectedSubscriber, uint64(cap(stalledSubscriber.frames)))
+
+	require.Equal(t, execstream.FrameTypeStdout, (<-reconnectedSubscriber.frames).Type)
+	require.Equal(t, execstream.FrameTypeExit, (<-reconnectedSubscriber.frames).Type)
+	require.Equal(t, execstream.FrameTypeNoMoreHistory, (<-reconnectedSubscriber.frames).Type)
 }
 
 func TestExecSessionDetachKeepsProcessAlive(t *testing.T) {

--- a/internal/controller/exec_sessions_test.go
+++ b/internal/controller/exec_sessions_test.go
@@ -278,7 +278,7 @@ func TestExecSessionLiveOutputAppliesBackpressure(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		for i := 0; i < frameCount; i++ {
+		for i := range frameCount {
 			session.recordFrame(&execstream.Frame{
 				Type: execstream.FrameTypeStdout,
 				Data: []byte{byte(i)},
@@ -294,7 +294,7 @@ func TestExecSessionLiveOutputAppliesBackpressure(t *testing.T) {
 		return len(subscriber.frames) == cap(subscriber.frames)
 	}, time.Second, time.Millisecond)
 
-	for i := 0; i < frameCount; i++ {
+	for i := range frameCount {
 		frame, ok := <-subscriber.frames
 		require.True(t, ok, "subscriber closed before output frame %d", i)
 		require.Equal(t, execstream.FrameTypeStdout, frame.Type)


### PR DESCRIPTION
## Summary

Live exec subscribers currently use a non-blocking send. When their 128-frame queue fills, Orchard disconnects the subscriber and loses subsequent output and the exit frame.

Reuse `sendLocked`, the blocking send path already used for history replay. This preserves frame order, applies backpressure, and still stops when the subscriber closes.

Add a regression test that sends 256 stdout frames and verifies the final exit frame.

## Reproduction

The regression fails on current `main` with `subscriber closed before output frame 128`.

## Verification

- `go test ./internal/controller -run '^TestExecSessionLiveOutputAppliesBackpressure$' -count=1`
- `go test ./internal/controller -count=1`
- `go test -race ./internal/controller -run '^TestExecSessionLiveOutputAppliesBackpressure$' -count=1`
- `go vet ./internal/controller`
- `git diff --check`
