### PR TITLE
Bump Golang version to 1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           cache: true
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.12.0
+          version: v2.13.0
           only-new-issues: true
 
   test-linux:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cirruslabs/orchard
 
-go 1.25.1
+go 1.27
 
 // Work around https://github.com/gin-gonic/gin/issues/4372
 replace github.com/gin-gonic/gin v1.11.0 => github.com/gin-gonic/gin v1.10.0


### PR DESCRIPTION
To get [faster JSON parsing](https://go.dev/doc/go1.27#jsonv2) for free.

See https://github.com/openai/orchard/pull/392 for more details.