### PR TITLE
Add an option to disable Tart clipboard sharing

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -747,6 +747,10 @@ components:
           type: boolean
           description: Whether to disable audio pass-through to the host
           default: false
+        noClipboard:
+          type: boolean
+          description: Whether to disable clipboard sharing between host and guest
+          default: false
         username:
           type: string
           description: SSH username to use when connecting to a VM

--- a/internal/command/create/vm.go
+++ b/internal/command/create/vm.go
@@ -29,6 +29,7 @@ var netBridged string
 var headless bool
 var nested bool
 var noAudio bool
+var noClipboard bool
 var suspendable bool
 var username string
 var password string
@@ -72,6 +73,7 @@ func newCreateVMCommand() *cobra.Command {
 	command.Flags().BoolVar(&headless, "headless", true, "whether to run without graphics")
 	command.Flags().BoolVar(&nested, "nested", false, "enable nested virtualization")
 	command.Flags().BoolVar(&noAudio, "no-audio", false, "disable audio pass-through to the host")
+	command.Flags().BoolVar(&noClipboard, "no-clipboard", false, "disable clipboard sharing between host and guest")
 	command.Flags().BoolVar(&suspendable, "suspendable", false, "treat the VM as suspendable, "+
 		"disabling certain devices for suspendability support and issuing \"tart suspend\" instead of \"tart stop\" "+
 		"when VM's specification is updated, thus preserving the VM's state between specification generations")
@@ -159,6 +161,7 @@ func runCreateVM(cmd *cobra.Command, args []string) error {
 		Headless:     headless,
 		Nested:       nested,
 		NoAudio:      noAudio,
+		NoClipboard:  noClipboard,
 		Username:     username,
 		Password:     password,
 		RandomSerial: randomSerial,

--- a/internal/command/get/vm.go
+++ b/internal/command/get/vm.go
@@ -99,6 +99,7 @@ func runGetVM(cmd *cobra.Command, args []string) error {
 	table.AddRow("Headless mode", vm.Headless)
 	table.AddRow("Nested virtualization", vm.Nested)
 	table.AddRow("Audio disabled", vm.NoAudio)
+	table.AddRow("Clipboard sharing disabled", vm.NoClipboard)
 	table.AddRow("Status", vm.Status)
 	table.AddRow("Status message", vm.StatusMessage)
 	table.AddRow("Assigned worker", nonEmptyOrNone(vm.Worker))

--- a/internal/worker/vmmanager/tart/tart.go
+++ b/internal/worker/vmmanager/tart/tart.go
@@ -307,6 +307,10 @@ func (vm *VM) run(ctx context.Context, eventStreamer *client.EventStreamer) {
 		runArgs = append(runArgs, "--no-audio")
 	}
 
+	if vm.resource.NoClipboard {
+		runArgs = append(runArgs, "--no-clipboard")
+	}
+
 	if vm.resource.Suspendable {
 		runArgs = append(runArgs, "--suspendable")
 	}

--- a/pkg/resource/v1/v1.go
+++ b/pkg/resource/v1/v1.go
@@ -33,6 +33,7 @@ type VM struct {
 	Headless        bool            `json:"headless,omitempty"`
 	Nested          bool            `json:"nested,omitempty"`
 	NoAudio         bool            `json:"noAudio,omitempty"`
+	NoClipboard     bool            `json:"noClipboard,omitempty"`
 
 	VMSpec
 	VMSpecReadOnly


### PR DESCRIPTION
Tart supports disabling clipboard sharing, but Orchard does not expose that option when creating a VM. Add the `noClipboard` VM field and `--no-clipboard` creation flag, pass the option to Tart, and expose it in VM inspection and the OpenAPI schema. Clipboard sharing remains enabled by default.

Validation: `go test -count=1 -timeout=120s ./pkg/resource/v1 ./internal/command/create ./internal/command/get ./internal/worker/vmmanager/tart`, plus the combined Orchard build.
