### PR TITLE
Bound worker log retention

### DIFF
--- a/internal/command/worker/run.go
+++ b/internal/command/worker/run.go
@@ -261,6 +261,12 @@ func readBootstrapToken() (string, error) {
 }
 
 func createLogger() (*zap.Logger, error) {
+	const (
+		maxLogSizeMB  = 100
+		maxLogBackups = 5
+		maxLogAgeDays = 14
+	)
+
 	level := zap.InfoLevel
 	if debug {
 		level = zap.DebugLevel
@@ -274,8 +280,11 @@ func createLogger() (*zap.Logger, error) {
 	}
 
 	logFileWriter := zapcore.AddSync(&lumberjack.Logger{
-		Filename: logFilePath,
-		MaxSize:  100, // megabytes
+		Filename:   logFilePath,
+		MaxSize:    maxLogSizeMB,
+		MaxBackups: maxLogBackups,
+		MaxAge:     maxLogAgeDays,
+		Compress:   true,
 	})
 	core := zapcore.NewCore(
 		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),


### PR DESCRIPTION
Worker log rotation limits the size of each file but leaves rotated backups unbounded. Keep at most five backups for up to fourteen days and compress them, while retaining the existing 100 MB rotation threshold.

Validation: `go test -count=1 -timeout=120s ./internal/command/worker` and the combined Orchard build.
