### PR TITLE
Worker: introduce automatic "org.cirruslabs.orchard.worker-name" label

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -142,6 +142,12 @@ func New(client *client.Client, opts ...Option) (*Worker, error) {
 
 	worker.resources = defaultResources.Merged(worker.resources)
 
+	defaultLabels := v1.Labels{
+		v1.LabelWorkerName: worker.name,
+	}
+
+	worker.labels = defaultLabels.Merged(worker.labels)
+
 	// Worker, VMs and images-related metrics
 	worker.vmPullTimeHistogram, err = opentelemetry.DefaultMeter.Float64Histogram(
 		"org.cirruslabs.orchard.worker.vm.pull_time",

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -237,6 +237,45 @@ func newWorkerWithFakeTart(
 	}
 }
 
+func TestWorkerNameLabel(t *testing.T) {
+	tests := []struct {
+		name               string
+		configuredLabels   v1.Labels
+		expectedWorkerName string
+	}{
+		{
+			name:               "automatic worker name",
+			configuredLabels:   v1.Labels{"custom-label": "custom-value"},
+			expectedWorkerName: recoveryTestWorkerName,
+		},
+		{
+			name: "explicit override",
+			configuredLabels: v1.Labels{
+				"custom-label":     "custom-value",
+				v1.LabelWorkerName: "custom-worker-name",
+			},
+			expectedWorkerName: "custom-worker-name",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			worker, err := New(
+				nil,
+				WithName(recoveryTestWorkerName),
+				WithLabels(test.configuredLabels),
+				WithSynthetic(),
+				WithLogger(zap.NewNop()),
+			)
+			require.NoError(t, err)
+			t.Cleanup(worker.pollTicker.Stop)
+
+			require.Equal(t, "custom-value", worker.labels["custom-label"])
+			require.Equal(t, test.expectedWorkerName, worker.labels[v1.LabelWorkerName])
+		})
+	}
+}
+
 func TestWorkerRecoversControllerSessionWithoutDeletingRunningVM(t *testing.T) {
 	firstHeartbeat := make(chan struct{})
 	reregistered := make(chan struct{})

--- a/pkg/resource/v1/labels.go
+++ b/pkg/resource/v1/labels.go
@@ -1,5 +1,11 @@
 package v1
 
+import "maps"
+
+const (
+	LabelWorkerName = "org.cirruslabs.orchard.worker-name"
+)
+
 type Labels map[string]string
 
 func (labels Labels) Contains(other Labels) bool {
@@ -10,4 +16,20 @@ func (labels Labels) Contains(other Labels) bool {
 	}
 
 	return true
+}
+
+func (labels Labels) Copy() Labels {
+	if labels == nil {
+		return make(Labels)
+	}
+
+	return maps.Clone(labels)
+}
+
+func (labels Labels) Merged(other Labels) Labels {
+	result := labels.Copy()
+
+	maps.Copy(result, other)
+
+	return result
 }

--- a/pkg/resource/v1/labels_test.go
+++ b/pkg/resource/v1/labels_test.go
@@ -1,9 +1,10 @@
 package v1_test
 
 import (
+	"testing"
+
 	v1 "github.com/cirruslabs/orchard/pkg/resource/v1"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestLabelsMatch(t *testing.T) {
@@ -42,4 +43,33 @@ func TestLabelsMatch(t *testing.T) {
 	b = map[string]string{"baz": "qux", "foo": "bar"}
 	require.False(t, a.Contains(b))
 	require.True(t, b.Contains(a))
+}
+
+func TestLabelsCopy(t *testing.T) {
+	original := v1.Labels{"foo": "bar"}
+	copied := original.Copy()
+	copied["foo"] = "changed"
+
+	require.Equal(t, v1.Labels{"foo": "bar"}, original)
+	require.Equal(t, v1.Labels{"foo": "changed"}, copied)
+	require.NotNil(t, v1.Labels(nil).Copy())
+}
+
+func TestLabelsMerged(t *testing.T) {
+	original := v1.Labels{
+		"preserved":  "original",
+		"overridden": "original",
+	}
+	overrides := v1.Labels{
+		"added":      "override",
+		"overridden": "override",
+	}
+
+	require.Equal(t, v1.Labels{
+		"added":      "override",
+		"overridden": "override",
+		"preserved":  "original",
+	}, original.Merged(overrides))
+	require.Equal(t, "original", original["overridden"])
+	require.Equal(t, "override", overrides["overridden"])
 }

--- a/pkg/resource/v1/labels_test.go
+++ b/pkg/resource/v1/labels_test.go
@@ -56,20 +56,26 @@ func TestLabelsCopy(t *testing.T) {
 }
 
 func TestLabelsMerged(t *testing.T) {
+	const (
+		originalValue = "original"
+		overriddenKey = "overridden"
+		overrideValue = "override"
+	)
+
 	original := v1.Labels{
-		"preserved":  "original",
-		"overridden": "original",
+		"preserved":   originalValue,
+		overriddenKey: originalValue,
 	}
 	overrides := v1.Labels{
-		"added":      "override",
-		"overridden": "override",
+		"added":       overrideValue,
+		overriddenKey: overrideValue,
 	}
 
 	require.Equal(t, v1.Labels{
-		"added":      "override",
-		"overridden": "override",
-		"preserved":  "original",
+		"added":       overrideValue,
+		overriddenKey: overrideValue,
+		"preserved":   originalValue,
 	}, original.Merged(overrides))
-	require.Equal(t, "original", original["overridden"])
-	require.Equal(t, "override", overrides["overridden"])
+	require.Equal(t, originalValue, original[overriddenKey])
+	require.Equal(t, overrideValue, overrides[overriddenKey])
 }

--- a/pkg/resource/v1/resources.go
+++ b/pkg/resource/v1/resources.go
@@ -35,13 +35,11 @@ func NewResourcesFromStringToString(
 }
 
 func (resources Resources) Copy() Resources {
-	result := make(Resources)
-
-	for key, value := range resources {
-		result[key] = value
+	if resources == nil {
+		return make(Resources)
 	}
 
-	return result
+	return maps.Clone(resources)
 }
 
 func (resources Resources) Add(other Resources) {
@@ -87,9 +85,7 @@ func (resources Resources) Merge(other Resources) {
 func (resources Resources) Merged(other Resources) Resources {
 	result := resources.Copy()
 
-	for otherKey, otherValue := range other {
-		result[otherKey] = otherValue
-	}
+	maps.Copy(result, other)
 
 	return result
 }


### PR DESCRIPTION
Simple quality-of-life improvement which allows setting `v1.VM` affinity to a specific worker.